### PR TITLE
Indentation sensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@ impl Greeter
   proc greet(target)
     echo(.greeting(target))
     .greetings = .greetings + 1
-  end
-
-end
 
 proc newGreeter =>
   Greeter { greetings = 0 }

--- a/src/tsuki/errors.nim
+++ b/src/tsuki/errors.nim
@@ -10,7 +10,7 @@ const
   peUnexpectedToken* = "unexpected token: '$#'"
   peXExpected* = "$# expected"
   peTokenMissing* = "missing '$#'"
-  peIndentLevel* = "indent level $# expected, but got $#"
+  peIndentLevel* = "$# spaces for indentation expected, but got $#"
 
   # compile errors
   ceSymUndeclared* = "undeclared symbol '$#'"

--- a/src/tsuki/errors.nim
+++ b/src/tsuki/errors.nim
@@ -10,6 +10,7 @@ const
   peUnexpectedToken* = "unexpected token: '$#'"
   peXExpected* = "$# expected"
   peTokenMissing* = "missing '$#'"
+  peIndentLevel* = "indent level $# expected, but got $#"
 
   # compile errors
   ceSymUndeclared* = "undeclared symbol '$#'"

--- a/src/tsuki/lexer.nim
+++ b/src/tsuki/lexer.nim
@@ -23,7 +23,7 @@ type
     tkFor = "for", tkIn = "in",
     tkBreak = "break", tkContinue = "continue"
     tkProc = "proc", tkReturn = "return"
-    tkBlock = "block", tkEnd = "end"
+    tkBlock = "block"
     tkObject = "object", tkImpl = "impl"
     tkImport = "import"
 

--- a/src/tsuki/lexer.nim
+++ b/src/tsuki/lexer.nim
@@ -50,6 +50,8 @@ type
       precedence*: int
     else: discard
 
+    indentLevel*: int
+
   LineInfo* = tuple
     line, column: int
 
@@ -67,6 +69,7 @@ type
     filename: FilenameId
     lineInfo: LineInfo
     storedLineInfo: LineInfo
+    indentLevel: int
 
   ParseError* = object of ValueError
     filename*: string
@@ -169,12 +172,18 @@ proc operatorToken(operator: string): Token =
     precedence: getPrecedence(operator)
   )
 
+proc line*(t: Token): int =
+  ## Returns the line number where the token is. This little shortcut is used to
+  ## more conveniently implement line sensitivity in the parser.
+  t.lineInfo.line
+
 {.pop.}
 
 proc repr*(t: Token): string =
   ## Debug representation for tokens.
 
-  result.add("($#, $#) " % [$t.lineInfo.line, $t.lineInfo.column])
+  result.add("($#, $#) I=$# " % [$t.lineInfo.line, $t.lineInfo.column,
+                                 $t.indentLevel])
   result.add($t.kind)
 
   case t.kind
@@ -259,6 +268,7 @@ proc error*(l: var Lexer, token: Token, message: string) =
 proc readChars(l: var Lexer, set: set[char], dest: var string) =
   ## Reads as many characters from the ``set`` as there are available to the
   ## ``dest`` string.
+
   while l.get in set:
     dest.add(l.get)
     l.advance()
@@ -275,11 +285,13 @@ proc readString(l: var Lexer, quote: char, dest: var string) =
     dest.add(l.get)
     l.advance()
 
-proc discardChars(l: var Lexer, set: set[char]) =
-  ## Discards characters from the given set.
+proc discardChars(l: var Lexer, set: set[char]): int =
+  ## Discards characters from the given set. Returns the number of discarded
+  ## characters.
 
   while l.get in set:
     l.advance()
+    inc result
 
 proc matchChar(l: var Lexer, set: set[char], dest: var string): bool =
   ## Consumes a single character from the ``set``, and adds it into ``dest``.
@@ -293,6 +305,11 @@ proc matchChar(l: var Lexer, set: set[char], dest: var string): bool =
 
 {.pop.}
 
+proc readIndent(l: var Lexer) =
+  ## Reads the indentation at the start of a line.
+
+  l.indentLevel = l.discardChars({' '})
+
 proc matchLinebreak*(l: var Lexer): bool =
   ## Returns true if a line break was matched.
   ## This skips any whitespace and comments first, then looks for line breaks.
@@ -301,24 +318,30 @@ proc matchLinebreak*(l: var Lexer): bool =
   while true:
     case l.get
     of whitespace:
-      l.discardChars(whitespace)
+      discard l.discardChars(whitespace)
     of '#':
-      l.discardChars(allChars - lineBreaks)
+      discard l.discardChars(allChars - lineBreaks)
     else: break
 
   # handle linebreaks if there are any
   while true:
     case l.get
     of '\n':
-      l.advance()
       inc l.lineInfo.line
-      l.lineInfo.column = 0
       result = true
     of '\r':
-      l.advance()
-      l.lineInfo.column = 0
       result = true
     else: break
+
+    l.advance()
+    reset l.lineInfo.column
+    reset l.indentLevel
+
+  # handle indentation, but only after line breaks.
+  # matchLinebreak serves double duty: ignoring whitespace, and tracking lines,
+  # so we don't wanna match newline if the latter doesn't happen
+  if result:
+    l.readIndent()
 
 proc skipIgnored*(l: var Lexer) =
   ## Skips comments, whitespace, and line breaks.
@@ -397,6 +420,7 @@ proc next*(l: var Lexer): Token =
 
   result.filename = l.filename
   result.lineInfo = l.storedLineInfo
+  result.indentLevel = l.indentLevel
 
 {.push inline.}
 
@@ -449,12 +473,13 @@ proc initLexer*(cs: CompilerState, filename: FilenameId,
                 input: string): Lexer {.inline.} =
   ## Creates and initializes a new lexer.
 
-  Lexer(
+  result = Lexer(
     cs: cs,
     input: input,
     filename: filename,
     lineInfo: liStartOfFile,
   )
+  result.readIndent()
 
 {.pop.}
 
@@ -497,7 +522,12 @@ when isMainModule:
     () [] {}
     , ;
     .
-  """
+
+    # indentation sensitivity
+    unindented
+      indented_a_bit
+          quite_the_indented
+  """.dedent
 
   var
     cs = new(CompilerState)

--- a/src/tsuki/parser.nim
+++ b/src/tsuki/parser.nim
@@ -459,45 +459,39 @@ when isMainModule:
       _
     else
       _
-    end
   """, l.parseExpr())
 
   # statements
   test("script", """
     var x = 1
     var y = 2
-    x + y * w;  # semicolon is required here because the next line starts with (
+    x + y * w
     (a + 1) * 2
   """, l.parseScript())
 
   test("while", """
     while true
       _
-    end
   """, l.parseScript())
 
   test("for", """
     for i in 1..10
       _
-    end
   """, l.parseScript())
 
   test("procedures", """
     proc long(a, b, c)
       _
-    end
 
     proc no_params
       _
-    end
 
-    proc short = _
+    proc short => _
 
-    proc forward = ...
+    proc forward => ...
 
     var closure = proc
       _
-    end
   """, l.parseScript())
 
   test("objects", """
@@ -510,8 +504,7 @@ when isMainModule:
     object Vec2 = x, y
 
     impl Vec2
-      proc x = .x
-      proc y = .y
-    end
+      proc x => .x
+      proc y => .y
 
   """, l.parseScript())

--- a/tests/essentials.tsu
+++ b/tests/essentials.tsu
@@ -47,13 +47,18 @@ block
 
 #. [block.expression]
 #. tests: "`block` as an expression"
-#. expect_output: "15"
+#. expect_output: """
+#.   15
+#.   3
+#. """
 
 var a = block
   var b = 30
   b / 2
+var b = block 1 + 2
 
 output(a)
+output(b)
 
 
 #.before

--- a/tests/essentials.tsu
+++ b/tests/essentials.tsu
@@ -19,7 +19,7 @@ output(b)
 
 
 #. [variables.local]
-#. tests: "`block` construct, declaring local variables, discarding locals"
+#. tests: "nested `block` construct, declaring local variables"
 #. expect_output: """
 #.   10
 #.   20
@@ -32,10 +32,8 @@ block
   block
     var b = 20
     output(b)
-  end
   var c = 30
   output(c)
-end
 
 
 #. [block.statement]
@@ -45,7 +43,6 @@ end
 block
   var x = 10
   output(x)
-end
 
 
 #. [block.expression]
@@ -55,7 +52,6 @@ end
 var a = block
   var b = 30
   b / 2
-end
 
 output(a)
 
@@ -240,7 +236,6 @@ block
     i = iter._next
     output(i)
   end
-end
 
 
 #. [controlflow.break]

--- a/tests/essentials.tsu
+++ b/tests/essentials.tsu
@@ -66,25 +66,24 @@ output(b)
 object Test = _
 
 impl Test
+
   proc test
     output("in test")
-  end
+
   proc inside
     output("in inside")
     .test()
-  end
+
   proc set=(x)
     output("in set=")
-  end
+
   proc %
     output("in %(_)")
-  end
+
   proc %(b)
     output("in %(_, _)")
-  end
-end
 
-var t = Test { _ = nil };
+var t = Test { _ = nil }
 
 #. [method.syntax_nkCall]
 #. tests: "calling methods via the `a.b()` syntax"
@@ -136,7 +135,6 @@ var a = true
 
 if a
   output("yes")
-end
 
 #. [if.else]
 #. tests: "`if…else` statement"
@@ -148,7 +146,6 @@ if a
   output("yes")
 else
   output("no")
-end
 
 #. [if.elif_else]
 #. tests: "`if…else…elif` statement"
@@ -163,7 +160,6 @@ elif b
   output("maybe")
 else
   output("no")
-end
 
 #. [if.expression]
 #. tests: "`if` as an expression"
@@ -174,7 +170,6 @@ var kind =
   if   i < 0  "negative"
   elif i == 0 "zero"
   else        "positive"
-  end
 
 output(kind)
 
@@ -190,7 +185,6 @@ output(
   else
     var b = 32
     b / 2
-  end
 )
 
 #. [while]
@@ -207,7 +201,6 @@ var i = 1
 while i <= 5
   output(i)
   i = i + 1
-end
 
 
 #. [for.countup]
@@ -222,7 +215,6 @@ end
 
 for i in 1..5
   output(i)
-end
 
 #. [for.emulated]
 #. tests: "`for` loop emulated with a `while` loop"
@@ -240,7 +232,6 @@ block
   while iter._hasNext
     i = iter._next
     output(i)
-  end
 
 
 #. [controlflow.break]
@@ -255,8 +246,6 @@ while true
   if a == 10
     var z = 10 + y
     break
-  end
-end
 
 #. [controlflow.continue]
 #. tests: "`continue` statements, its interaction between variables in scope"
@@ -272,9 +261,7 @@ for a in 1..5
   if a == 3
     var z = 20
     continue
-  end
   output(a)
-end
 
 
 #. [proc.simple]
@@ -283,7 +270,6 @@ end
 
 proc hello
   output("hello")
-end
 
 hello()
 
@@ -295,7 +281,6 @@ proc fib(n) =>
   if   n == 0  0
   elif n == 1  1
   else         fib(n - 1) + fib(n - 2)
-  end
 
 output(fib(10))
 
@@ -308,10 +293,7 @@ proc loop(x)
   while true
     if x >= 10
       return x + 10
-    end
     x = x + 3
-  end
-end
 
 output(loop(31))
 
@@ -323,8 +305,6 @@ proc fac(n)
   result = 1
   for i in 1..n
     result = result * i
-  end
-end
 
 output(fac(10))
 
@@ -354,11 +334,8 @@ impl Counter
 
   proc count()
     .i = .i + 1
-  end
 
   proc value => .i
-
-end
 
 proc newCounter(initialValue) =>
   Counter { i = initialValue }
@@ -369,4 +346,4 @@ output(c.value)
 while c.value < 5
   c.count()
   output(c.value)
-end
+

--- a/tests/essentials.tsu
+++ b/tests/essentials.tsu
@@ -65,7 +65,7 @@ impl Test
     output("in test")
   end
   proc inside
-    output("in inside"); # gosh i really need to implement line sensitivity
+    output("in inside") # gosh i really need to implement line sensitivity
     .test()
   end
   proc set=(x)

--- a/tests/essentials.tsu
+++ b/tests/essentials.tsu
@@ -70,7 +70,7 @@ impl Test
     output("in test")
   end
   proc inside
-    output("in inside") # gosh i really need to implement line sensitivity
+    output("in inside")
     .test()
   end
   proc set=(x)


### PR DESCRIPTION
This adds an indentation sensitive parser to the language and alters its syntax so that `end` is not needed. `proc` still requires you to use the special `=>` syntax if you want to return a single expression though; in my opinion the intent is more clear that way.